### PR TITLE
Supports fieldsId for customFields

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -80,10 +80,13 @@ export const convertSchema = (name: string, schema: MicroCMSSchemaType) => {
       return `${getDoc(fields)}\n${fieldId}${!required ? '?' : ''}: ${getKindType(fields)}`;
     });
   };
+  const getCustomFields = (fieldId: string, fields: MicroCMSFieldType[]) => {
+    return [`fieldId: '${fieldId}'`, ...getFields(fields)];
+  };
 
   const mainSchema = getFields(apiFields);
   const customSchemas = Object.fromEntries(
-    customFields.map(({ fieldId, fields }) => [fieldId, getFields(fields)])
+    customFields.map(({ fieldId, fields }) => [fieldId, getCustomFields(fieldId, fields)])
   );
   return { mainSchema, customSchemas };
 };


### PR DESCRIPTION
繰り返しのカスタムフィールドを利用する際に`fieldId`で情報を出し分けることがあり、またmicroCMSのレスポンスにもfieldIdが含まれているので追加しました。

## microCMS JSON
`api-news-20220804195333.json`
```json
{
  "apiFields": [
    {
      "idValue": "VKz2DRAfju",
      "fieldId": "category",
      "name": "カテゴリー",
      "kind": "relation",
      "required": true,
      "referenceDisplayItem": "1VeK3PU3N_"
    },
    {
      "fieldId": "title",
      "name": "タイトル",
      "kind": "text",
      "required": true,
      "isUnique": false
    },
    {
      "fieldId": "contents",
      "name": "内容",
      "kind": "repeater",
      "required": false,
      "customFieldCreatedAtList": [
        "2022-08-04T10:38:53.943Z",
        "2022-08-04T10:39:29.580Z",
        "2022-08-04T10:39:58.343Z",
        "2022-08-04T10:42:16.565Z"
      ]
    },
    {
      "fieldId": "coverImage",
      "name": "カバー画像",
      "kind": "media"
    },
    {
      "fieldId": "relatedNews",
      "name": "関連お知らせ",
      "kind": "relationList",
      "relationListCountLimitValidation": {
        "relationListCount": {
          "min": null,
          "max": 4
        }
      }
    }
  ],
  "customFields": [
    {
      "createdAt": "2022-08-04T10:38:53.943Z",
      "fieldId": "richEditor",
      "name": "リッチエディタ",
      "fields": [
        {
          "idValue": "QwamnszSrV",
          "fieldId": "content",
          "name": "リッチエディタ",
          "kind": "richEditor",
          "required": true,
          "richEditorOptions": [
            "headerOne",
            "headerTwo",
            "headerThree",
            "headerFour",
            "headerFive",
            "paragraph",
            "bold",
            "italic",
            "underline",
            "strike",
            "code",
            "align",
            "blockquote",
            "codeBlock",
            "listOrdered",
            "listBullet",
            "scriptSub",
            "scriptSuper",
            "link",
            "clean",
            "background",
            "color"
          ]
        }
      ],
      "position": [["QwamnszSrV"]],
      "updatedAt": "2022-08-04T10:38:53.943Z",
      "viewerGroup": "sHm"
    },
    {
      "createdAt": "2022-08-04T10:39:29.580Z",
      "fieldId": "html",
      "name": "HTML",
      "fields": [
        {
          "idValue": "c7v6zV4889",
          "fieldId": "content",
          "name": "HTML",
          "kind": "textArea",
          "required": true
        }
      ],
      "position": [["c7v6zV4889"]],
      "updatedAt": "2022-08-04T10:39:29.580Z",
      "viewerGroup": "sHm"
    },
    {
      "createdAt": "2022-08-04T10:39:58.343Z",
      "fieldId": "markdown",
      "name": "Markdown",
      "fields": [
        {
          "idValue": "btwzYdGABV",
          "fieldId": "content",
          "name": "Markdown",
          "kind": "textArea",
          "required": true
        }
      ],
      "position": [["btwzYdGABV"]],
      "updatedAt": "2022-08-04T10:39:58.343Z",
      "viewerGroup": "sHm"
    },
    {
      "createdAt": "2022-08-04T10:42:16.565Z",
      "fieldId": "image",
      "name": "画像",
      "fields": [
        {
          "idValue": "4I7jyhflyT",
          "fieldId": "alt",
          "name": "代替えテキスト",
          "kind": "text",
          "required": false
        },
        {
          "idValue": "lOJ2zuaOTA",
          "fieldId": "image",
          "name": "画像",
          "kind": "media",
          "required": true
        },
        {
          "idValue": "YC8kzTVSbG",
          "fieldId": "position",
          "name": "配置",
          "kind": "select",
          "required": true,
          "selectItems": [
            {
              "id": "oQQfRu9-n_",
              "value": "左寄せ"
            },
            {
              "id": "40o7UswJdO",
              "value": "中央寄せ"
            },
            {
              "id": "2ZqkHNAk3P",
              "value": "右寄せ"
            }
          ],
          "multipleSelect": false
        }
      ],
      "position": [["lOJ2zuaOTA", "YC8kzTVSbG"], ["4I7jyhflyT"]],
      "updatedAt": "2022-08-04T10:42:25.871Z",
      "viewerGroup": "sHm"
    }
  ]
}
```

## Result
```ts
type Reference<T, R> = T extends 'get' ? R : string | null;
interface GetsType<T> {
  contents: T[];
  totalCount: number;
  offset: number;
  limit: number;
}
type DateType = {
  createdAt: string;
  updatedAt: string;
  publishedAt: string;
  revisedAt: string;
};
type Structure<T, P> = T extends 'get'
  ? { id: string } & DateType & Required<P>
  : T extends 'gets'
  ? GetsType<{ id: string } & DateType & Required<P>>
  : Partial<DateType> & (T extends 'patch' ? Partial<P> : P);

export type news<T='get'> = Structure<
T,
{
  /**
   * カテゴリー
   */
  category: Reference<T,unknown>
  /**
   * タイトル
   */
  title: string
  /**
   * 内容
   */
  contents?: (news_richEditor | news_html | news_markdown | news_image)[]
  /**
   * カバー画像
   */
  coverImage?: { url: string, width: number, height: number }
  /**
   * 関連お知らせ
   */
  relatedNews?: Reference<T,unknown>[]
}>

interface news_richEditor {
  fieldId: 'richEditor'
  /**
   * リッチエディタ
   */
  content: string
}
interface news_html {
  fieldId: 'html'
  /**
   * HTML
   */
  content: string
}
interface news_markdown {
  fieldId: 'markdown'
  /**
   * Markdown
   */
  content: string
}
interface news_image {
  fieldId: 'image'
  /**
   * 代替えテキスト
   */
  alt?: string
  /**
   * 画像
   */
  image: { url: string, width: number, height: number }
  /**
   * 配置
   */
  position: ['左寄せ' | '中央寄せ' | '右寄せ']
}

export interface EndPoints {
  get: {
    'news': news<'get'>
  }
  gets: {
    'news': news<'gets'>
  }
  post: {
    'news': news<'post'>
  }
  put: {
    'news': news<'put'>
  }
  patch: {
    'news': news<'patch'>
  }
}
```